### PR TITLE
fixed issue in list method. When supplying a startAfter key where only 1...

### DIFF
--- a/src/groovy/com/reachlocal/grails/plugins/cassandra/mapping/ClassMethods.groovy
+++ b/src/groovy/com/reachlocal/grails/plugins/cassandra/mapping/ClassMethods.groovy
@@ -218,7 +218,16 @@ class ClassMethods extends MappingUtils
 
 				def rows = cassandra.persistence.getRows(ks, columnFamily, keys, opts.consistencyLevel)
 				def result = cassandra.mapping.makeResult(keys, rows, options, clazz, LinkedList)
-				return options.startAfter && result ? result[1..-1] : result
+
+                if (options.startAfter && result) {
+                    if (result.size() <= 1) {
+                            return []
+                    } else {
+                        return result[1..-1]
+                    }
+                } else {
+                    return result
+                }
 			}
 		}
 

--- a/test/unit/com/reachlocal/grails/plugins/cassandra/test/ClassMethodsTests.groovy
+++ b/test/unit/com/reachlocal/grails/plugins/cassandra/test/ClassMethodsTests.groovy
@@ -262,6 +262,12 @@ public class ClassMethodsTests extends OrmTestCase
 		println r
 		assertEquals 2, r.size()
 
+		println "\n--- list(startAfter: 'x5', max: 10) ---"
+		r = User.list(startAfter: 'x5', max: 10)
+		persistence.printClear()
+		println r
+		assertEquals 0, r.size()
+
 		println "\n--- list(start: 'x4z', finish: 'x3z', reversed: true) ---"
 		r = User.list(start: 'x4z', finish: 'x3z', reversed:  true) as List
 		persistence.printClear()


### PR DESCRIPTION
... row is in the result an index out of bounds error was being thrown when returning "result[1..-1]"
