### PR TITLE
Added ability to specify consistency level in 1:1 accessor methods

### DIFF
--- a/CassandraOrmGrailsPlugin.groovy
+++ b/CassandraOrmGrailsPlugin.groovy
@@ -19,7 +19,7 @@ import com.reachlocal.grails.plugins.cassandra.uuid.UuidDynamicMethods
 
 class CassandraOrmGrailsPlugin
 {
-	def version = "1.2.5"
+	def version = "1.2.6"
 	def grailsVersion = "2.0.0 > *"
 	def author = "Bob Florian"
 	def authorEmail = "bob.florian@reachlocal.com"

--- a/test/unit/com/reachlocal/grails/plugins/cassandra/test/InstanceMethodTests.groovy
+++ b/test/unit/com/reachlocal/grails/plugins/cassandra/test/InstanceMethodTests.groovy
@@ -150,7 +150,7 @@ class InstanceMethodTests extends OrmTestCase
 		persistence.printClear()
 
 		println "\n--- userGroup.insert(name: JUG2) ---"
-		userGroup3.insert([name: 'GUG2'], 75)
+		userGroup3.insert([name: 'GUG2'], [ttl: 75, consistencyLevel: "CL_QUORUM"])
 		persistence.printClear()
 
 		println "\n--- userGroup.color [EXPANDO] ---"
@@ -310,8 +310,20 @@ class InstanceMethodTests extends OrmTestCase
 		println "${r} (${r?.uuid})"
 		assertNotNull r
 
+		println "\n--- user4.userGroup() ---"
+		r = user4.userGroup(consistencyLevel: "CL_QUORUM")
+		persistence.printClear()
+		println "${r} (${r?.uuid})"
+		assertNotNull r
+
 		println "\n--- user4.userGroupId ---"
 		r = user4.userGroupId
+		persistence.printClear()
+		println r
+		assertEquals "group2-zzzz-zzzz", r
+
+		println "\n--- user4.userGroupId() ---"
+		r = user4.userGroupId(consistencyLevel: "CL_QUORUM")
 		persistence.printClear()
 		println r
 		assertEquals "group2-zzzz-zzzz", r


### PR DESCRIPTION
Also changes some existing places where ttl could be specified to use consistent `ttl: value` options syntax
