### PR TITLE
Modified save and insert to always use the same mutation batch

### DIFF
--- a/CassandraOrmGrailsPlugin.groovy
+++ b/CassandraOrmGrailsPlugin.groovy
@@ -19,7 +19,7 @@ import com.reachlocal.grails.plugins.cassandra.uuid.UuidDynamicMethods
 
 class CassandraOrmGrailsPlugin
 {
-	def version = "1.2.6"
+	def version = "1.3.0"
 	def grailsVersion = "2.0.0 > *"
 	def author = "Bob Florian"
 	def authorEmail = "bob.florian@reachlocal.com"

--- a/src/java/com/reachlocal/grails/plugins/cassandra/utils/IndexHelper.java
+++ b/src/java/com/reachlocal/grails/plugins/cassandra/utils/IndexHelper.java
@@ -44,5 +44,12 @@ public class IndexHelper
 				}
 			}
 		}
+
+		for (Object key: oldIndexRows.keySet().toArray()) {
+			if (indexRows.containsKey(key)) {
+				oldIndexRows.remove(key);
+				indexRows.remove(key);
+			}
+		}
 	}
 }


### PR DESCRIPTION
In cases where relationships or indexed values were updated multiple mutation batches were used since the plugin was deleting all keys and then re-adding them. New approach removes keys that are unchanged and does everything in one mutation batch.
