### PR TITLE
Filter nulls out of explicit index query results

### DIFF
--- a/CassandraOrmGrailsPlugin.groovy
+++ b/CassandraOrmGrailsPlugin.groovy
@@ -19,7 +19,7 @@ import com.reachlocal.grails.plugins.cassandra.uuid.UuidDynamicMethods
 
 class CassandraOrmGrailsPlugin
 {
-	def version = "1.3.0"
+	def version = "1.3.1"
 	def grailsVersion = "2.0.0 > *"
 	def author = "Bob Florian"
 	def authorEmail = "bob.florian@reachlocal.com"

--- a/test/unit/com/reachlocal/grails/plugins/cassandra/test/InstanceMethodTests.groovy
+++ b/test/unit/com/reachlocal/grails/plugins/cassandra/test/InstanceMethodTests.groovy
@@ -342,10 +342,10 @@ class InstanceMethodTests extends OrmTestCase
 		println "\n"
 		r = UserGroupMeeting.list()
 		persistence.printClear()
-		assertEquals 6, r.size()
+		assertEquals 3, r.size()
 		userGroup2.delete(cascade: true)
 		persistence.printClear()
 		r = UserGroupMeeting.list()
-		assertEquals 4, r.size()
+		assertEquals 1, r.size()
 	}
 }


### PR DESCRIPTION
Nulls result when the index has entries and the main table does not, due to errors on consistency issues.
